### PR TITLE
Add Dev_exit to fix example 2in13_V3

### DIFF
--- a/python/lib/TP_lib/epd2in13_V3.py
+++ b/python/lib/TP_lib/epd2in13_V3.py
@@ -428,6 +428,8 @@ class EPD:
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
+
+    def Dev_exit(self):
         epdconfig.module_exit()
 
 ### END OF FILE ###


### PR DESCRIPTION
When Ctrl+C is pressed, an error is thrown.
> AttributeError: 'EPD' object has no attribute 'Dev_exit'

Signed-off-by: akgnah <1024@setq.me>